### PR TITLE
Keeps numeric values with '+' prefix (e.g., "+43") as string

### DIFF
--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -51,7 +51,7 @@ class TranslatableFieldMixin
 
                 if (!empty($value)) {
                     $value = array_map(function ($val) {
-                        return !is_numeric($val) || (is_string($val) && $val[0] === '0') ? $val : (float) $val;
+                        return !is_numeric($val) || (is_string($val) && ($val[0] === '0' || $val[0] === '+')) ? $val : (float) $val;
                     }, (array) $value);
                 }
 


### PR DESCRIPTION
Hello,

If in a translatable text input you type a numeric string prefixed by a plus sign, e.g. "+43", the value will be converted as float and the plus sign is lost. 

Similarly to what was previously done with numeric values prefixed by zeros, I'm now also considering the "+" prefix as a sign that the value should be kept as a string.
