### PR TITLE
Do not cast string 0 to float within Text field

### DIFF
--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -77,7 +77,7 @@ class TranslatableFieldMixin
 
                 if($this instanceof Text && !$this instanceof Number) {
                     foreach ($value as $key => $val) {
-                        $value[$key] = ( $val === null ? null : (string) $val) ;
+                        $value[$key] = ( $val === null ? null : (string) $val );
                     }
                 }
 

--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Support\Arr;
 use Laravel\Nova\Fields\Markdown;
 use Laravel\Nova\Fields\Textarea;
+use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class TranslatableFieldMixin
@@ -72,6 +73,12 @@ class TranslatableFieldMixin
                 $fillOtherLocalesFrom = isset($options['fillOtherLocalesFrom'])
                     ? $options['fillOtherLocalesFrom']
                     : config('nova-translatable.fill_other_locales_from', null);
+
+                if($this instanceof Text) {
+                    foreach ($value as $key => $val) {
+                        $value[$key] = ( $val === null ? null : (string) $val) ;
+                    }
+                }
 
                 $translatable = [
                     'original_attribute' => $this->attribute,

--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Laravel\Nova\Fields\Markdown;
 use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class TranslatableFieldMixin
@@ -74,7 +75,7 @@ class TranslatableFieldMixin
                     ? $options['fillOtherLocalesFrom']
                     : config('nova-translatable.fill_other_locales_from', null);
 
-                if($this instanceof Text) {
+                if($this instanceof Text && !$this instanceof Number) {
                     foreach ($value as $key => $val) {
                         $value[$key] = ( $val === null ? null : (string) $val) ;
                     }


### PR DESCRIPTION
We ran into an issue where nova-translatable was casting user provided string `0` to float before it was serialized to send to the front end.

Unlike PHP, JS (Vue that renders) considers float 0 as falsy and is not rendering in some fields. How this was manifesting is user was providing a `0` value within the text field and it would save, upon view / edit the field would be presented as empty.

![image](https://github.com/outl1ne/nova-translatable/assets/48888686/9536d51f-8641-4a94-b898-1fc741ded54e)

Proposed change would cast values within a `Text` field (but not `Number` as `Number ` extends `Text`) to a string which I think is logical as a translation of a text field should be considered a string type.
