### PR TITLE
Remove z-index

### DIFF
--- a/resources/js/components/LocaleTabs.vue
+++ b/resources/js/components/LocaleTabs.vue
@@ -69,7 +69,6 @@ export default {
 <style lang="scss">
 .nova-translatable-locale-tabs {
   position: relative;
-  z-index: 2;
   padding-top: 0.25rem;
 
   .locale-tag {


### PR DESCRIPTION
Not sure why it's there? It's causing issues with popups. For example with popups from: https://github.com/advoor/nova-editor-js

<img width="574" alt="image" src="https://github.com/outl1ne/nova-translatable/assets/1703233/510f6f5e-91c4-4bf0-8d40-a1af3852d41d">