### PR TITLE
Fix showing translations for languages with no key set

### DIFF
--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -76,7 +76,7 @@ class TranslatableFieldMixin
                     : config('nova-translatable.fill_other_locales_from', null);
 
                 // Fix strings being casted to floats
-                if ($this instanceof Text && !$this instanceof Number) {
+                if ($this instanceof Text && !$this instanceof Number && !empty($value)) {
                     foreach ($value as $key => $val) {
                         $value[$key] = ($val === null ? null : (string) $val);
                     }


### PR DESCRIPTION
This PR fixes showing translations where there is no key for a lanauge.

For example, currently, if you set locales to `fa` and `en` and a translatable field value is `{"en": null}`, An error will be shown:

`foreach() argument must be of type array|object, string given`