### PR TITLE
feat: custom display for locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ The configuration option `fill_other_locales_from` allows you to pre-fill other 
 
 If you don't want to display the locale select next to each field, you can set the `display_type` to `none` and add a `Outl1ne\NovaTranslatable\Fields\LocaleSelect` field to your Nova resource. This will render a single select for all fields.
 
+### Custom locale display
+
+To customize the locale display you can use `Nova::provideToScript` to pass `customLocaleDisplay` as in the example below.
+
+```php
+// in app/Providers/NovaServiceProvider.php
+
+public function boot()
+{
+    Nova::serving(function () {
+        Nova::provideToScript([
+            // ...
+            'customLocaleDisplay' => [
+                'en' => <img src="/flag-en.png"/>,
+                'et' => <img src="/flag-et.png"/>,
+            ]
+        ]);
+    });
+}
+```
+
 ## Edge cases
 
 #### BelongsToMany allowDuplicateRelations corner-case

--- a/resources/js/components/LocaleTabs.vue
+++ b/resources/js/components/LocaleTabs.vue
@@ -16,9 +16,8 @@
         }"
         @click="() => $emit('tabClick', locale.key)"
         @dblclick="() => $emit('doubleClick', locale.key)"
-      >
-        {{ locale.name }}
-      </a>
+        v-html="getLocaleDisplay(locale)"
+      />
     </div>
   </div>
 </template>
@@ -61,6 +60,16 @@ export default {
       }
 
       return locale + '.locale.tab';
+    },
+
+    getLocaleDisplay(locale) {
+      const customDisplay = Nova.config('customLocaleDisplay');
+
+      if (customDisplay && customDisplay[locale.key]) {
+        return customDisplay[locale.key];
+      }
+
+      return locale.name;
     },
   },
 };


### PR DESCRIPTION
Ability to have custom display for locales:

![image](https://github.com/user-attachments/assets/d987b4e2-f2e0-46f5-ae38-fe6cfc154672)

Related to https://github.com/outl1ne/nova-menu-builder/pull/209