### PR TITLE
Fix cast issue in TranslatableFieldMixin

### DIFF
--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -76,7 +76,7 @@ class TranslatableFieldMixin
                     : config('nova-translatable.fill_other_locales_from', null);
 
                 // Fix strings being casted to floats
-                if ($this instanceof Text && !$this instanceof Number) {
+                if ($this instanceof Text && !$this instanceof Number && !empty($value)) {
                     foreach ($value as $key => $val) {
                         $value[$key] = ($val === null ? null : (string) $val);
                     }


### PR DESCRIPTION
Ensure non-empty values are cast to string only if not null, enhancing data handling and preventing unintended type conversion for empty strings.
