### PR TITLE
Use Arrayable interface when casting to array

### DIFF
--- a/src/TranslatableFieldMixin.php
+++ b/src/TranslatableFieldMixin.php
@@ -3,6 +3,7 @@
 namespace Outl1ne\NovaTranslatable;
 
 use Exception;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Laravel\Nova\Fields\Markdown;
 use Laravel\Nova\Fields\Textarea;
@@ -44,7 +45,11 @@ class TranslatableFieldMixin
                 try {
                     if (!is_array($value)) {
                         if (is_object($value)) {
-                            $value = (array) $value;
+                            if($value instanceof Arrayable) {
+                                $value = $value->toArray();
+                            } else {
+                                $value = (array) $value;
+                            }
                         } else {
                             $testValue = json_decode($value, true);
                             if (is_array($testValue)) $value = $testValue;


### PR DESCRIPTION
This pull request enables the use of spatie/data in conjunction with attribute casting.

Spatie's BaseData implements - like many other classes - Laravel's Arrayable Interface. This makes the `toArray()` method available, which can (and maybe should) be used instead of `(array)`.
In this way, only the desired values of the attribute become part of the array instead of casting the internal structures as well.